### PR TITLE
docs: register alexmskills as an Antora content source

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -45,6 +45,10 @@ content:
       edit_url: false
       branches: main
       start_path: docs
+    - url: https://github.com/alexmond/alexmskills.git
+      edit_url: false
+      branches: main
+      start_path: docs
 
 ui:
   bundle:


### PR DESCRIPTION
Adds the `alexmond/alexmskills` repo (its `docs/` Antora component) to the site playbook so the skills-marketplace documentation builds and deploys at **alexmond.org/alexmskills**.

⚠️ **Merge order:** merge [alexmond/alexmskills#1](https://github.com/alexmond/alexmskills/pull/1) **first** so `alexmskills` exists on `main` — this playbook source points at `branches: main`, and the site build will fail until that content is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)