### PR TITLE
ci: deploy docs to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs to GitHub Pages
+name: Deploy Docs to Cloudflare Pages + GitHub Pages
 
 on:
   push:
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  deployments: write
 
 concurrency:
   group: "pages"
@@ -29,33 +30,27 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
+
       - name: Build with Maven
         run: mvn -B package --file pom.xml --no-transfer-progress
 
-      # Ensure the target directory exists (fail early if not built)
       - name: Verify docs output exists
         run: |
           pwd
-          mkdir target/site/sitemaps
+          mkdir -p target/site/sitemaps
           cp target/site/sitemap*.xml target/site/sitemaps
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: pages/
-          
-      - name: Copy files to server via SCP
-        uses: appleboy/scp-action@v1
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
         with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-#          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          password: ${{ secrets.SSH_PASS }}
-          port: 22
-          source: "target/site/*"
-          target: "."
-          strip_components: 2
-          overwrite: true
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy target/site --project-name=alexmond-org --branch=main
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- Replaces the IONOS SCP deploy step with `cloudflare/wrangler-action` publishing `target/site/` to the `alexmond-org` Pages project (created today: `alexmond-org.pages.dev`).
- Keeps the GitHub Pages artifact path intact as a free secondary mirror.

## Why
We migrated the `alexmond.org` zone to Cloudflare today and want the static Antora site served from Cloudflare Pages with a real LE cert and global CDN instead of from IONOS shared hosting. Frees us to cancel the IONOS hosting product.

## Repo secrets
- `CLOUDFLARE_API_TOKEN` ✅ added
- `CLOUDFLARE_ACCOUNT_ID` ✅ added
- `SSH_HOST/USER/PASS/PRIVATE_KEY` — can be deleted after merge (no longer used).

## Test plan
- [ ] Merge → workflow runs → wrangler deploys `target/site/` → check Actions log for the Pages URL.
- [ ] Visit `https://alexmond-org.pages.dev/` to confirm the same content as `https://www.alexmond.org/`.
- [ ] Then attach custom domains `alexmond.org` + `www.alexmond.org` to the Pages project (via API), at which point CF auto-rewrites the apex/www DNS records from the IONOS IPs to the Pages hostname.