### PR TITLE
Publish versioned extensions docs (3.5.15.1, 4.0.7.1, 4.1.0.1)

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -25,7 +25,7 @@ content:
       edit_url: false
     - url: https://github.com/alexmond/spring-boot-actuator-extensions.git
       branches: []
-      tags: 1.0.4
+      tags: [3.5.15.1, 4.0.7.1, 4.1.0.1]
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/spring-boot-playground.git


### PR DESCRIPTION
## What

Update the `spring-boot-actuator-extensions` content source in `antora-playbook.yml` from the stale single tag `1.0.4` to the current released tags:

```diff
-      tags: 1.0.4
+      tags: [3.5.15.1, 4.0.7.1, 4.1.0.1]
```

## Why

The extensions repo now maintains three release lines, each with a Maven Central release and a git tag:

| Tag | Spring Boot | Line |
|-----|-------------|------|
| `3.5.15.1` | 3.5.15 | `3.5` maintenance branch |
| `4.0.7.1` | 4.0.7 | `4.0` maintenance branch |
| `4.1.0.1` | 4.1.0 | `main` |

The extensions Antora component uses `version: true`, so each tag becomes a selectable doc version. With `latest_version_segment: current`, **`4.1.0.1` becomes `/extensions/current/`** (matching the pom `<url>`), and the site gains a version dropdown across all three lines.

All three tags are verified present on the extensions remote, so the Antora build can fetch them.

## Publishing

Merging to `main` triggers `deploy_docs.yml` (GitHub Pages + Cloudflare Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)