### PR TITLE
Add notify4j (0.2.0) to the docs hub

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -41,6 +41,11 @@ content:
       tags: 2.0.2
       start_path: docs
       edit_url: false
+    - url: https://github.com/alexmond/notify4j.git
+      branches: []
+      tags: 0.2.0
+      start_path: docs
+      edit_url: false
     - url: https://github.com/alexmond/jhelm.git
       edit_url: false
       branches: main

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -35,6 +35,12 @@ link:/yj-schema-validator/current/index.html[Learn more about yj-schema-validato
 Collection of custom Spring Boot Actuator endpoints and extensions to enhance application monitoring and management capabilities.
 link:/extensions/current/index.html[Learn more about Actuator Extensions^]
 
+=== notify4j
+
+An embeddable, domain-agnostic multi-channel notification library for Java/Spring Boot — no server to run. Declare channels as Apprise/shoutrrr-style URLs (Slack, Teams, Discord, Telegram, ntfy, webhook, PagerDuty, OpsGenie, and email) and get status-transition filtering, runtime mute, tag-based routing, and reminders for free.
+
+link:/notify4j/current/index.html[Learn more about notify4j^]
+
 === JSupervisor
 
 A Spring Boot implementation of a process supervisor system for monitoring and managing multiple processes in a Java environment. Provides lifecycle management, health monitoring through HTTP, TCP, Actuator and command-line checks, and configurable log rotation.

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -27,6 +27,8 @@
                             JSON Schema Generator</a>
                         <a class="navbar-item"
                            href="https://www.alexmond.org/yj-schema-validator/current/index.html">YJ Schema Validator</a>
+                        <a class="navbar-item"
+                           href="https://www.alexmond.org/notify4j/current/index.html">notify4j</a>
                         <a class="navbar-item" href="https://www.alexmond.org/extensions/current/index.html">Actuator
                             extensions</a>
                         <a class="navbar-item" href="https://www.alexmond.org/jsupervisor/current/index.html">JSupervisor</a>
@@ -42,6 +44,7 @@
                             JSON Schema Generator</a>
                         <a class="navbar-item" href="https://github.com/alexmond/yj-schema-validator">YJ Schema
                             Validator</a>
+                        <a class="navbar-item" href="https://github.com/alexmond/notify4j">notify4j</a>
                         <a class="navbar-item" href="https://github.com/alexmond/spring-boot-actuator-extensions">Actuator
                             extensions</a>
                         <a class="navbar-item" href="https://github.com/alexmond/jsupervisor">JSupervisor</a>


### PR DESCRIPTION
notify4j 0.2.0 was just published to Maven Central; this surfaces its docs on the hub.

- add `notify4j` as an Antora content source pinned to the `0.2.0` tag (released-library pattern, like yj-schema-validator)
- add a notify4j entry to the homepage project list
- add notify4j to the Projects and Repositories navbar dropdowns

Component resolves to `/notify4j/current/` (the URL notify4j's README/POM already reference). Playbook YAML validated; the `0.2.0` tag carries `docs/antora.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)