### PR TITLE
Add gotmpl4j to the docs hub

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -50,6 +50,10 @@ content:
       edit_url: false
       branches: main
       start_path: docs
+    - url: https://github.com/alexmond/gotmpl4j.git
+      edit_url: false
+      branches: main
+      start_path: docs
     - url: https://github.com/alexmond/alexmskills.git
       edit_url: false
       branches: main

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -53,6 +53,12 @@ A native Java implementation of the Helm package manager for Kubernetes. Enables
 
 link:/jhelm/index.html[Learn more about JHelm^]
 
+=== gotmpl4j
+
+A pure-Java implementation of Go's `text/template` engine, with the Sprig function library and an optional Spring Boot starter — no Go toolchain or native bindings. It renders the same templates Helm, Hugo, and countless Go CLIs use, and is validated for byte-for-byte parity against Go's own `text/template` test suite and Sprig's upstream tests. This is the engine that powers JHelm.
+
+link:/gotmpl4j/current/index.html[Learn more about gotmpl4j^]
+
 === Spring Boot Examples
 
 Collection of Spring Boot example projects demonstrating various features and integration patterns.

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -35,6 +35,7 @@
                         <a class="navbar-item" href="https://www.alexmond.org/samples/current/index.html">Spring Boot
                             examples</a>
                         <a class="navbar-item" href="https://www.alexmond.org/jhelm/index.html">JHelm</a>
+                        <a class="navbar-item" href="https://www.alexmond.org/gotmpl4j/current/index.html">gotmpl4j</a>
                     </div>
                 </div>
                 <div class="navbar-item has-dropdown is-hoverable" style="min-width: 280px">
@@ -51,6 +52,7 @@
                         <a class="navbar-item" href="https://github.com/alexmond/spring-boot-playground">Spring Boot
                             examples</a>
                         <a class="navbar-item" href="https://github.com/alexmond/jhelm">JHelm</a>
+                        <a class="navbar-item" href="https://github.com/alexmond/gotmpl4j">gotmpl4j</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Adds [gotmpl4j](https://github.com/alexmond/gotmpl4j) — a pure-Java implementation of Go's `text/template` engine, with the Sprig function library and an optional Spring Boot starter — to the docs hub.

- **Playbook**: new content source tracking `main` (unreleased; matches the jhelm pattern).
- **Homepage**: section under JHelm, noting it's the engine that powers JHelm.
- **Navbar**: entries in both the Projects and Repositories dropdowns.

Publishes at `/gotmpl4j/current/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)