### PR TITLE
Pin gotmpl4j docs to released tag 0.1.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -51,9 +51,10 @@ content:
       branches: main
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
-      edit_url: false
-      branches: main
+      branches: []
+      tags: 0.1.0
       start_path: docs
+      edit_url: false
     - url: https://github.com/alexmond/alexmskills.git
       edit_url: false
       branches: main


### PR DESCRIPTION
gotmpl4j released 0.1.0. Pin the hub content source to the tag instead of tracking `main`, matching the released-library pattern. The tag contains `docs/` (verified) and publishes under `/gotmpl4j/current/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)