### PR TITLE
Bump notify4j docs to 0.4.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -43,7 +43,7 @@ content:
       edit_url: false
     - url: https://github.com/alexmond/notify4j.git
       branches: []
-      tags: 0.2.0
+      tags: 0.4.0
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/jhelm.git


### PR DESCRIPTION
Pins the notify4j content source to the `0.4.0` release tag (was `0.2.0`). Publishes docs for the four new channels, the Teams→Workflows fix, and async delivery + retry. URL stays `/notify4j/current/` (latest-version segment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)