### PR TITLE
Bump gotmpl4j docs to 0.2.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -52,7 +52,7 @@ content:
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
       branches: []
-      tags: 0.1.0
+      tags: 0.2.0
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/alexmskills.git


### PR DESCRIPTION
gotmpl4j released 0.2.0. Pins the hub content source to the new tag (verified it carries docs/). Continues publishing at /gotmpl4j/current/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)