### PR TITLE
Bump notify4j docs to 0.5.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -43,7 +43,7 @@ content:
       edit_url: false
     - url: https://github.com/alexmond/notify4j.git
       branches: []
-      tags: 0.4.0
+      tags: 0.5.0
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/jhelm.git


### PR DESCRIPTION
Pins the notify4j source to the `0.5.0` tag (was `0.4.0`). The tag carries `notify4j-version: 0.5.0`, so the published install snippet is now correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)