### PR TITLE
Pin jhelm docs to 0.1.0 (first release)

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -48,7 +48,8 @@ content:
       edit_url: false
     - url: https://github.com/alexmond/jhelm.git
       edit_url: false
-      branches: main
+      branches: []
+      tags: 0.1.0
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
       branches: []


### PR DESCRIPTION
jhelm shipped its first public release (0.1.0, on Maven Central). Flip its hub content source from `branches: main` to the pinned `0.1.0` tag so the site serves stable release docs instead of `0.2.0-SNAPSHOT` main. The tag carries `docs/` and the URL shape is unchanged (`/jhelm/index.html`).