### PR TITLE
Bump gotmpl4j docs to 0.3.1

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -53,7 +53,7 @@ content:
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
       branches: []
-      tags: 0.3.0
+      tags: 0.3.1
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/alexmskills.git


### PR DESCRIPTION
gotmpl4j 0.3.1 (date-layout fix + dead-property/CI cleanup). Pins the hub to the new tag.