### PR TITLE
Bump gotmpl4j docs to 0.3.2

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -53,7 +53,7 @@ content:
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
       branches: []
-      tags: 0.3.1
+      tags: 0.3.2
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/alexmskills.git


### PR DESCRIPTION
gotmpl4j 0.3.2 (dep bumps + javadoc.io API links). Pins the hub to the new tag.