### PR TITLE
Bump notify4j docs to 0.7.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -43,7 +43,7 @@ content:
       edit_url: false
     - url: https://github.com/alexmond/notify4j.git
       branches: []
-      tags: 0.6.0
+      tags: 0.7.0
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/jhelm.git


### PR DESCRIPTION
Pins notify4j to the `0.7.0` tag. 🤖 Generated with [Claude Code](https://claude.com/claude-code)