### PR TITLE
Bump gotmpl4j docs to 1.0.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -53,7 +53,7 @@ content:
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
       branches: []
-      tags: 0.3.2
+      tags: 1.0.0
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/alexmskills.git


### PR DESCRIPTION
Pins the gotmpl4j docs source to the released `1.0.0` tag (was `0.3.2`). The tag carries `docs/` with `version: true` + `{page-component-version}`, so install snippets and javadoc.io API links track 1.0.0 automatically.