### PR TITLE
ci: builder pipeline analogs

### DIFF
--- a/.builder/pipelines/deploy_docs.yml
+++ b/.builder/pipelines/deploy_docs.yml
@@ -1,0 +1,41 @@
+name: Deploy Docs
+on:
+  - push
+  - manual
+push:
+  branches:
+    - main
+jobs:
+  build:
+    image: eclipse-temurin:17-jdk
+    timeout: 30m
+    cache:
+      key: m2-pages
+      paths:
+        - .m2/repository
+    artifacts:
+      - target/site
+    steps:
+      - name: checkout
+        run: git clone --depth 1 https://github.com/alexmond/alexmond.github.io.git .
+      - name: build
+        run: mvn -B package --file pom.xml --no-transfer-progress -Dmaven.repo.local=.m2/repository
+      - name: verify-docs-output
+        run: |
+          pwd
+          mkdir -p target/site/sitemaps
+          cp target/site/sitemap*.xml target/site/sitemaps
+
+  deploy:
+    image: node:20
+    needs:
+      - build
+    when: manual
+    needs-artifacts:
+      - build
+    secrets:
+      - CLOUDFLARE_API_TOKEN
+      - CLOUDFLARE_ACCOUNT_ID
+    steps:
+      - name: publish-cloudflare-pages
+        run: npx --yes wrangler pages deploy target/site --project-name=alexmond-org --branch=main


### PR DESCRIPTION
Adds a builder pipeline mirroring the GitHub Actions docs workflow under .builder/pipelines/.

The build job clones the repo and runs the Maven Antora build (JDK 17) with an m2 cache, matching deploy_docs.yml. A manual deploy job carries the Cloudflare Pages publish step.

This is additive and inert: GitHub Actions remains the live CI, and nothing here runs until a builder webhook is wired to the repo.

Gaps: builder has no native GitHub Pages deploy (the upload-pages-artifact / deploy-pages steps are dropped); the Cloudflare publish needs CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID secrets configured in builder; concurrency cancel-in-progress has no direct equivalent.