### PR TITLE
Add jvmlens (0.1.0) to the docs hub

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -56,6 +56,11 @@ content:
       tags: 1.0.0
       start_path: docs
       edit_url: false
+    - url: https://github.com/alexmond/jvmlens.git
+      branches: []
+      tags: 0.1.0
+      start_path: docs
+      edit_url: false
     - url: https://github.com/alexmond/alexmskills.git
       edit_url: false
       branches: main

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -59,6 +59,12 @@ A pure-Java implementation of Go's `text/template` engine, with the Sprig functi
 
 link:/gotmpl4j/current/index.html[Learn more about gotmpl4j^]
 
+=== jvmlens
+
+Turn JVM runtime evidence into an LLM-ready diagnosis. jvmlens reads a JFR recording and emits a few hundred tokens of ranked, source-attributed signal — hot paths, allocation sites, lock contention, GC pressure, a hedged cause — where a raw `jfr print` dump is hundreds of thousands of tokens. A CLI (`analyze`/`profile`/`bench`/`watch`/`trend`/`mcp`), an in-process `-javaagent`, a JMH profiler, and a scoped MCP server all reuse the one dependency-free engine. It serves data only — never calls an LLM, never ships recordings anywhere.
+
+link:/jvmlens/current/index.html[Learn more about jvmlens^]
+
 === Spring Boot Examples
 
 Collection of Spring Boot example projects demonstrating various features and integration patterns.

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -36,6 +36,7 @@
                             examples</a>
                         <a class="navbar-item" href="https://www.alexmond.org/jhelm/index.html">JHelm</a>
                         <a class="navbar-item" href="https://www.alexmond.org/gotmpl4j/current/index.html">gotmpl4j</a>
+                        <a class="navbar-item" href="https://www.alexmond.org/jvmlens/current/index.html">jvmlens</a>
                     </div>
                 </div>
                 <div class="navbar-item has-dropdown is-hoverable" style="min-width: 280px">
@@ -53,6 +54,7 @@
                             examples</a>
                         <a class="navbar-item" href="https://github.com/alexmond/jhelm">JHelm</a>
                         <a class="navbar-item" href="https://github.com/alexmond/gotmpl4j">gotmpl4j</a>
+                        <a class="navbar-item" href="https://github.com/alexmond/jvmlens">jvmlens</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
First release of **jvmlens** (turn JVM runtime evidence into an LLM-ready diagnosis) is public and tagged `0.1.0` (the tag carries `docs/`). Pin it on the hub:

- **playbook** — content source pinned to `tags: 0.1.0` (released lib; `version: true` → served at `/jvmlens/current/`).
- **homepage** — `=== jvmlens` section near the other JVM tools.
- **navbar** — added to both Projects (docs) and Repositories (GitHub) dropdowns.