### PR TITLE
Add UniTrack (0.2.0) to the docs hub

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -18,6 +18,10 @@ content:
       edit_url: false
       branches: main
       worktrees: true
+    - url: https://github.com/alexmond/unitrack.git
+      edit_url: false
+      branches: main
+      start_path: docs
     - url: https://github.com/alexmond/spring-boot-config-json-schema.git
       tags: 1.0.9
       branches: []

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -13,6 +13,12 @@ Browse through the projects below to learn more about what I'm working on.
 
 == Projects
 
+=== UniTrack
+
+A self-hosted server for tracking test execution and code coverage over time — Allure-meets-Codecov, and polyglot (JVM, Go, .NET, Node, and more). CI uploads JUnit/Surefire results plus JaCoCo/Cobertura/LCOV/OpenCover coverage and load-test results (JMeter, k6, JMH) via a CLI, a GitHub Action, or the REST API; UniTrack renders trends over a true time axis, flaky-test detection, quality gates, failure clustering with click-to-run AI root-cause analysis, and a board that surfaces slow regressions with a "broken since" rot signal. Includes per-project API tokens, email/Slack alerts, GitHub PR checks, and an MCP server for AI assistants.
+
+link:/unitrack/index.html[Learn more about UniTrack^]
+
 === alexmskills — Claude Code Skills Marketplace
 
 A curated https://code.claude.com[Claude Code] plugin marketplace of reusable, *self-improving* skills and agents — each an independently versioned plugin. It includes a self-evolving `CLAUDE.md`, a delivery crew that composes a task-fit roster to ship a target, a brainstorm panel, and a shared *evolving-roles* system that lets one persona run solo, as a crew role, or as a panel seat while accumulating what it learns.

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -22,6 +22,7 @@
                 <div class="navbar-item has-dropdown is-hoverable">
                     <a class="navbar-link" href="#">Projects</a>
                     <div class="navbar-dropdown lg">
+                        <a class="navbar-item" href="https://www.alexmond.org/unitrack/index.html">UniTrack</a>
                         <a class="navbar-item"
                            href="https://www.alexmond.org/spring-boot-config-json-schema-starter/current/index.html">Config
                             JSON Schema Generator</a>
@@ -42,6 +43,7 @@
                 <div class="navbar-item has-dropdown is-hoverable" style="min-width: 280px">
                     <a class="navbar-link" href="#">Repositories</a>
                     <div class="navbar-dropdown lg">
+                        <a class="navbar-item" href="https://github.com/alexmond/unitrack">UniTrack</a>
                         <a class="navbar-item" href="https://github.com/alexmond/spring-boot-config-json-schema">Config
                             JSON Schema Generator</a>
                         <a class="navbar-item" href="https://github.com/alexmond/yj-schema-validator">YJ Schema


### PR DESCRIPTION
Adds the UniTrack project to the hub:

- **Playbook**: `unitrack` content source tracking `main` (docs `version: master` → served at `/unitrack/index.html`). Tracks main rather than pinning `v0.2.0` because the tag carries a stale `unitrack-version: 0.2.0-SNAPSHOT`; main has the correct `0.2.0` + the latest AI/board docs.
- **Homepage**: UniTrack section (flagship, listed first).
- **Navbar**: added to both the Projects and Repositories dropdowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)