### PR TITLE
Branding: rename site to "Alex Mondshain" + fix navbar logo alt

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -2,7 +2,7 @@ antora:
   extensions:
     - require: '@springio/antora-extensions/root-attachments-extension'
 site:
-  title: Alex Mondshain's Developer Hub
+  title: Alex Mondshain
   # the 404 page and sitemap files only get generated when the url property is set
   url: https://www.alexmond.org/
   start_page: home::index.adoc

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -6,7 +6,7 @@
                         id="apower"
                         class="navbar-logo"
                         src="{{{uiRootPath}}}/img/apower-logo.svg"
-                        alt="APower"
+                        alt="Alex Mondshain"
                 />
             </a>
             <a class="navbar-item" href="{{{or site.url siteRootPath}}}">{{site.title}}</a>


### PR DESCRIPTION
Two small branding fixes (the rename from the homepage PR got pushed after that merge, so it never landed).

- **`site.title`** → **"Alex Mondshain"** (was "Alex Mondshain's Developer Hub"). Drives the navbar brand + browser-tab suffix; "Developer Hub" describes the format, not the value — the positioning lives in the homepage hero now. Personal/author brand, consistent with @alexmond / org.alexmond / alexmond.org.
- **Navbar logo `alt`** → "Alex Mondshain" (was "APower", a UI-template leftover).

Note: the logo image itself (`supplemental-ui/img/apower-logo.svg`) is still the template's borrowed mark — an abstract square, no visible "APower" text. With the alt fixed it no longer misrepresents, but it's not *your* mark. Worth replacing with your own logo or removing the image and letting the "Alex Mondshain" text brand stand. Happy to do either.