### PR TITLE
Bump jhelm docs to 0.4.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -53,7 +53,7 @@ content:
     - url: https://github.com/alexmond/jhelm.git
       edit_url: false
       branches: []
-      tags: 0.1.0
+      tags: 0.4.0
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
       branches: []


### PR DESCRIPTION
Pin the jhelm content source to the **0.4.0** release tag (was 0.1.0). The tag carries `docs/antora.yml` with `jhelm-version: 0.4.0`, so the published docs + install snippets track the new release. (Homepage/navbar entries already exist; URL shape `/jhelm/` unchanged.)