### PR TITLE
Bump gotmpl4j docs to 1.1.1

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -57,7 +57,7 @@ content:
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
       branches: []
-      tags: 1.0.0
+      tags: 1.1.1
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/jvmlens.git


### PR DESCRIPTION
Pins gotmpl4j to the new 1.1.1 release tag. Surfaces the new **Performance** benchmark page and the quantified **conformance** numbers (1,305 cases). The hub was still on 1.0.0 (it never moved to 1.1.0), so this also clears that staleness.