### PR TITLE
Bump gotmpl4j docs to 1.1.2

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -57,7 +57,7 @@ content:
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
       branches: []
-      tags: 1.1.1
+      tags: 1.1.2
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/jvmlens.git


### PR DESCRIPTION
Pins gotmpl4j to the 1.1.2 release. Publishes the expanded Performance page (enriched cross-engine Stocks comparison — gotmpl4j now ties Mustache for the interpreter lead — plus the new gotmpl4j feature-suite section) and the quantified conformance numbers.