### PR TITLE
Bump notify4j docs to 1.0.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -47,7 +47,7 @@ content:
       edit_url: false
     - url: https://github.com/alexmond/notify4j.git
       branches: []
-      tags: 0.7.0
+      tags: 1.0.0
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/jhelm.git


### PR DESCRIPTION
Pin the notify4j docs source to the released tag 1.0.0 (was 0.7.0). Serves at /notify4j/current/.