### PR TITLE
Bump gotmpl4j docs to 1.1.3

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -57,7 +57,7 @@ content:
       start_path: docs
     - url: https://github.com/alexmond/gotmpl4j.git
       branches: []
-      tags: 1.1.2
+      tags: 1.1.3
       start_path: docs
       edit_url: false
     - url: https://github.com/alexmond/jvmlens.git


### PR DESCRIPTION
Pins gotmpl4j to 1.1.3. Publishes the new feature-suite vs Go+Sprig reference comparison (gotmpl4j 2–11× faster across the Sprig/control-flow surface) and the #80 allocation optimization.